### PR TITLE
feat: zeromq

### DIFF
--- a/vcpkg-overlay/ports/zeromq/eintr-retry.patch
+++ b/vcpkg-overlay/ports/zeromq/eintr-retry.patch
@@ -1,0 +1,51 @@
+diff --git a/src/zmq.cpp b/src/zmq.cpp
+index 271d8049..f7a3e4d1 100644
+--- a/src/zmq.cpp
++++ b/src/zmq.cpp
+@@ -609,18 +609,26 @@ int zmq_msg_init_data (
+ int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
+ {
+     zmq::socket_base_t *s = as_socket_base_t (s_);
+     if (!s)
+         return -1;
+-    return s_sendmsg (s, msg_, flags_);
++    int rc;
++    do {
++        rc = s_sendmsg (s, msg_, flags_);
++    } while (rc < 0 && errno == EINTR);
++    return rc;
+ }
+
+ int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_)
+ {
+     zmq::socket_base_t *s = as_socket_base_t (s_);
+     if (!s)
+         return -1;
+-    return s_recvmsg (s, msg_, flags_);
++    int rc;
++    do {
++        rc = s_recvmsg (s, msg_, flags_);
++    } while (rc < 0 && errno == EINTR);
++    return rc;
+ }
+
+ int zmq_msg_close (zmq_msg_t *msg_)
+@@ -960,7 +968,14 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
+         {
+             const int rc = poll (&pollfds[0], nitems_, timeout);
+             if (rc == -1 && errno == EINTR) {
+-                return -1;
++                if (timeout_ > 0) {
++                    if (first_pass) {
++                        now = clock.now_ms ();
++                        end = now + timeout_;
++                        first_pass = false;
++                    } else
++                        now = clock.now_ms ();
++                    if (now >= end)
++                        return 0;
++                }
++                continue;
+             }
+             errno_assert (rc >= 0);
+         }

--- a/vcpkg-overlay/ports/zeromq/fix-arm.patch
+++ b/vcpkg-overlay/ports/zeromq/fix-arm.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dd3d8eb..c08cad9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -551,6 +551,8 @@ if(ZMQ_HAVE_WINDOWS)
+   set(CMAKE_REQUIRED_LIBRARIES "")
+   # TODO: This not the symbol we're looking for. What is the symbol?
+   check_library_exists(ws2 fopen "" HAVE_WS2)
++  
++  check_cxx_symbol_exists(CryptAcquireContext "windows.h;wincrypt.h" HAVE_ADVAPI32)
+ else()
+   check_cxx_symbol_exists(if_nametoindex net/if.h HAVE_IF_NAMETOINDEX)
+   check_cxx_symbol_exists(SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
+@@ -1452,6 +1454,10 @@ if(BUILD_SHARED)
+   elseif(HAVE_WS2)
+     target_link_libraries(libzmq ws2)
+   endif()
++  
++  if (HAVE_ADVAPI32)
++    target_link_libraries(libzmq advapi32)
++  endif()
+ 
+   if(HAVE_RPCRT4)
+     target_link_libraries(libzmq rpcrt4)
+@@ -1497,6 +1503,10 @@ if(BUILD_STATIC)
+   elseif(HAVE_WS2)
+     target_link_libraries(libzmq-static ws2)
+   endif()
++  
++  if (HAVE_ADVAPI32)
++    target_link_libraries(libzmq-static advapi32)
++  endif()
+ 
+   if(HAVE_RPCRT4)
+     target_link_libraries(libzmq-static rpcrt4)
+diff --git a/src/clock.cpp b/src/clock.cpp
+index 79522ad..0667c59 100644
+--- a/src/clock.cpp
++++ b/src/clock.cpp
+@@ -41,8 +41,10 @@
+ #include <cmnintrin.h>
+ #else
+ #include <intrin.h>
+-#if defined(_M_ARM) || defined(_M_ARM64)
++#if defined(_M_ARM)
+ #include <arm_neon.h>
++#elif defined(_M_ARM64)
++#include <arm64_neon.h>
+ #endif
+ #endif
+ #endif

--- a/vcpkg-overlay/ports/zeromq/portfile.cmake
+++ b/vcpkg-overlay/ports/zeromq/portfile.cmake
@@ -1,0 +1,78 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zeromq/libzmq
+    REF "v${VERSION}"
+    SHA512 108d9c5fa761c111585c30f9c651ed92942dda0ac661155bca52cc7b6dbeb3d27b0dd994abde206eacfc3bc88d19ed24e45b291050c38469e34dca5f8c9a037d
+    PATCHES
+        fix-arm.patch
+        eintr-retry.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        sodium            WITH_LIBSODIUM
+        draft             ENABLE_DRAFTS
+        websockets        ENABLE_WS
+        websockets-secure WITH_TLS
+        curve             ENABLE_CURVE
+)
+
+set(PLATFORM_OPTIONS "")
+if(VCPKG_TARGET_IS_MINGW)
+    list(APPEND PLATFORM_OPTIONS "-DCMAKE_SYSTEM_VERSION=6.0" "-DZMQ_HAVE_IPC=0")
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DZMQ_BUILD_TESTS=OFF
+        -DBUILD_STATIC=${BUILD_STATIC}
+        -DBUILD_SHARED=${BUILD_SHARED}
+        -DWITH_PERF_TOOL=OFF
+        -DWITH_DOCS=OFF
+        -DWITH_NSS=OFF
+        -DWITH_LIBBSD=OFF
+        -DCMAKE_REQUIRE_FIND_PACKAGE_GnuTLS=ON
+        -DWITH_LIBSODIUM_STATIC=${BUILD_STATIC}
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+    OPTIONS_DEBUG
+        "-DCMAKE_PDB_OUTPUT_DIRECTORY=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_REQUIRE_FIND_PACKAGE_GnuTLS
+        WITH_LIBBSD
+        WITH_PERF_TOOL
+        WITH_TLS
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
+else()
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ZeroMQ)
+endif()
+
+file(COPY
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/share/zmq")
+
+vcpkg_fixup_pkgconfig()

--- a/vcpkg-overlay/ports/zeromq/vcpkg-cmake-wrapper.cmake
+++ b/vcpkg-overlay/ports/zeromq/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,9 @@
+_find_package(${ARGS})
+
+if(TARGET libzmq AND NOT TARGET libzmq-static)
+    add_library(libzmq-static INTERFACE IMPORTED)
+    set_target_properties(libzmq-static PROPERTIES INTERFACE_LINK_LIBRARIES libzmq)
+elseif(TARGET libzmq-static AND NOT TARGET libzmq)
+    add_library(libzmq INTERFACE IMPORTED)
+    set_target_properties(libzmq PROPERTIES INTERFACE_LINK_LIBRARIES libzmq-static)
+endif()

--- a/vcpkg-overlay/ports/zeromq/vcpkg.json
+++ b/vcpkg-overlay/ports/zeromq/vcpkg.json
@@ -1,0 +1,56 @@
+{
+  "name": "zeromq",
+  "version": "4.3.5",
+  "port-version": 2,
+  "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
+  "homepage": "https://github.com/zeromq/libzmq",
+  "license": "MPL-2.0",
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "curve": {
+      "description": "Enable CURVE security"
+    },
+    "draft": {
+      "description": "Build and install draft APIs"
+    },
+    "sodium": {
+      "description": "Using libsodium for CURVE security",
+      "dependencies": [
+        "libsodium",
+        {
+          "name": "zeromq",
+          "default-features": false,
+          "features": [
+            "curve"
+          ]
+        }
+      ]
+    },
+    "websockets": {
+      "description": "Enable WebSocket transport"
+    },
+    "websockets-secure": {
+      "description": "Enable WebSocket transport with TSL (wss)",
+      "dependencies": [
+        "libgnutls",
+        {
+          "name": "zeromq",
+          "default-features": false,
+          "features": [
+            "websockets"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
patch EINTR retry
https://github.com/MaaEnd/MaaEnd/issues/2539

## Summary by Sourcery

为 ZeroMQ 添加一个自定义的 vcpkg overlay 端口，包含特定平台的配置和封装集成。

新特性：
- 为 ZeroMQ（libzmq）库引入 vcpkg overlay 端口，包括特性标志和特定平台的选项。

缺陷修复：
- 为 libzmq 应用 EINTR 重试补丁，以解决短暂的中断系统调用错误。
- 为 ARM 平台应用特定补丁，以提升 libzmq 在 ARM 平台上的兼容性。

改进：
- 提供一个 CMake 封装器，在不同链接配置下都能暴露一致的 `libzmq` 和 `libzmq-static` 目标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a custom vcpkg overlay port for ZeroMQ with platform-specific configuration and wrapper integration.

New Features:
- Introduce a vcpkg overlay port for the ZeroMQ (libzmq) library, including feature flags and platform-specific options.

Bug Fixes:
- Apply an EINTR retry patch to libzmq to address transient interrupted system call errors.
- Apply an ARM-specific patch to improve libzmq compatibility on ARM platforms.

Enhancements:
- Provide a CMake wrapper to expose consistent libzmq and libzmq-static targets regardless of linkage configuration.

</details>